### PR TITLE
parser: Lift Parser into StateT

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,21 +1,14 @@
 module Main where
 
+import           Control.Applicative
 import           Control.Monad
-import           Dzang.Parser
+import qualified Dzang.Parser                  as P
+import           Dzang.StatefulParser
 
-data Number = Number Integer Integer
+newtype Number = Number Integer
   deriving Show
 
 main :: IO ()
 main = forever $ do
   l <- getLine
-  print $ runParser p l
- where
-  p = spaces *> res <* spaces
-  res :: Parser Number
-  res =
-    mkNumber
-      <*> number
-      <*> (spaces >> optional (separator ',') >> spaces >> number)
-  mkNumber :: Parser (Integer -> Integer -> Number)
-  mkNumber = return Number
+  print $ runParser (spaces *> number) l

--- a/dzang.cabal
+++ b/dzang.cabal
@@ -27,9 +27,11 @@ library
   hs-source-dirs:      src
   exposed-modules:     Dzang
                      , Dzang.Parser
+                     , Dzang.StatefulParser
                      , Dzang.Language
   build-depends:       text
                      , transformers
+                     , mtl
 
 executable dzang-exe
   import: shared

--- a/src/Dzang/StatefulParser.hs
+++ b/src/Dzang/StatefulParser.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE LambdaCase #-}
+module Dzang.StatefulParser where
+
+import           Control.Applicative
+import           Control.Monad.State.Lazy
+import           Data.Char
+import           Data.Functor                   ( (<&>) )
+import qualified Dzang.Parser                  as P
+
+data ParserState = ParserState
+  { _line :: Int
+  , _col  :: Int
+  }
+  deriving Show
+
+-- Although lifting our existing `P.Parser` into the `StateT` transformer
+-- allows us to track external state, all the functions would have to be
+-- rewritten or adapted to allow for dependency injection. The culprit here is
+-- `item`, which is the only function that really updates the state and is used
+-- for every combinator behind the curtains.
+
+type Parser a = StateT ParserState P.Parser a
+
+runParser :: Parser a -> String -> [((a, ParserState), String)]
+runParser p s = let parser = runStateT p (ParserState 1 1) in P.parse parser s
+
+incCol :: ParserState -> ParserState
+incCol s = s { _col = _col s + 1 }
+
+incLine :: ParserState -> ParserState
+incLine s = s { _line = _line s + 1 }
+
+item :: Parser Char
+item = lift P.item >>= \case
+  '\n' -> modify incLine >> return '\n'
+  c    -> modify incCol >> return c
+
+satisfy :: (Char -> Bool) -> Parser Char
+satisfy p = item >>= \c -> if p c then return c else empty
+
+number :: Parser Integer
+number = many (satisfy isDigit) <&> read
+
+space :: Parser Char
+space = satisfy isSpace
+
+spaces :: Parser String
+spaces = many space


### PR DESCRIPTION
Exemplary implementation of lifting the `Dzang.Parser` into the `StateT` monad.
I realised this is not really nice because the tracking of position for the input stream relies on the `item` primitive. Every basic combinator has to use the `item` primitive to advance the stream and assure proper tracking of the `Parser` state.

This basically tells me, that `State` would have to be a first class primitive, otherwise the Parser cannot be easily extended/composed with other `mtl` transformers.